### PR TITLE
Remove CORS middleware

### DIFF
--- a/pkg/must-gather-api.go
+++ b/pkg/must-gather-api.go
@@ -54,15 +54,6 @@ func setupRouter() *gin.Engine {
 	// Setup middleware to validate bearer auth tokens against the cluster
 	r.Use(backend.DefaultAuth.Permit)
 
-	// Prepare CORS
-	//r.Use(cors.New(cors.Config{
-	//	AllowMethods:     []string{"GET", "POST"},
-	//	AllowHeaders:     []string{"Authorization", "Origin"},
-	//	AllowOriginFunc:  corsAllow,
-	//	AllowCredentials: true,
-	//	MaxAge:           12 * time.Hour,
-	//}))
-
 	// Setup routes for must-gather functions
 	r.POST("/must-gather", triggerGathering)
 	r.GET("/must-gather", listGatherings) // good at least during development and testing, real user should know gathering ID
@@ -133,25 +124,3 @@ func prepareAddr(port string) string {
 	}
 	return addr
 }
-
-// CORS functions
-//func corsAllow(origin string) bool {
-//	for _, expr := range corsAllowedOrigins {
-//		if expr.MatchString(origin) {
-//			return true
-//		}
-//	}
-//
-//	return false
-//}
-
-//func corsBuildOrigins() {
-//	corsAllowedOrigins = []*regexp.Regexp{}
-//	for _, r := range ConfigEnvOrDefault("CORS_ALLOWED_ORIGINS", "") {
-//		expr, err := regexp.Compile(r)
-//		if err != nil {
-//			continue
-//		}
-//		corsAllowedOrigins = append(corsAllowedOrigins, expr)
-//	}
-//}

--- a/pkg/must-gather-api.go
+++ b/pkg/must-gather-api.go
@@ -58,7 +58,7 @@ func setupRouter() *gin.Engine {
 
 	// Prepare CORS
 	r.Use(cors.New(cors.Config{
-		AllowMethods:     []string{"GET"},
+		AllowMethods:     []string{"GET", "POST"},
 		AllowHeaders:     []string{"Authorization", "Origin"},
 		AllowOriginFunc:  corsAllow,
 		AllowCredentials: true,

--- a/pkg/must-gather-api.go
+++ b/pkg/must-gather-api.go
@@ -4,9 +4,7 @@ import (
 	"log"
 	"regexp"
 	"strings"
-	"time"
 
-	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/forklift-must-gather-api/pkg/backend"
 	"gorm.io/gorm"
@@ -50,20 +48,20 @@ func setupRouter() *gin.Engine {
 	r = gin.Default()
 
 	r.GET("/", func(c *gin.Context) {
-		c.String(200, "must-gather-api - for API see https://github.com/konveyor/forklift-must-gather-api#README")
+		c.String(200, "must-gather-api - for API see https://github.com/konveyor/forklift-must-gather-api#README no cors")
 	})
 
 	// Setup middleware to validate bearer auth tokens against the cluster
 	r.Use(backend.DefaultAuth.Permit)
 
 	// Prepare CORS
-	r.Use(cors.New(cors.Config{
-		AllowMethods:     []string{"GET", "POST"},
-		AllowHeaders:     []string{"Authorization", "Origin"},
-		AllowOriginFunc:  corsAllow,
-		AllowCredentials: true,
-		MaxAge:           12 * time.Hour,
-	}))
+	//r.Use(cors.New(cors.Config{
+	//	AllowMethods:     []string{"GET", "POST"},
+	//	AllowHeaders:     []string{"Authorization", "Origin"},
+	//	AllowOriginFunc:  corsAllow,
+	//	AllowCredentials: true,
+	//	MaxAge:           12 * time.Hour,
+	//}))
 
 	// Setup routes for must-gather functions
 	r.POST("/must-gather", triggerGathering)
@@ -137,15 +135,15 @@ func prepareAddr(port string) string {
 }
 
 // CORS functions
-func corsAllow(origin string) bool {
-	for _, expr := range corsAllowedOrigins {
-		if expr.MatchString(origin) {
-			return true
-		}
-	}
-
-	return false
-}
+//func corsAllow(origin string) bool {
+//	for _, expr := range corsAllowedOrigins {
+//		if expr.MatchString(origin) {
+//			return true
+//		}
+//	}
+//
+//	return false
+//}
 
 //func corsBuildOrigins() {
 //	corsAllowedOrigins = []*regexp.Regexp{}


### PR DESCRIPTION
There was partially implemented CORS middleware in gin-gonic. Since the deployment in forklift-operator mounts proxy to the must-gather-api to path under tha same hostname. The API communication is single-origin, so CORS should not be required - removing it.