### PR TITLE
Remove k8s client caching

### DIFF
--- a/pkg/backend/auth.go
+++ b/pkg/backend/auth.go
@@ -187,11 +187,6 @@ func (r *Auth) key(token, p string) string {
 //
 // Build API writer.
 func (r *Auth) writer(cfg *rest.Config) (w client.Writer, err error) {
-	if r.Writer != nil {
-		w = r.Writer
-		return
-	}
-
 	w, err = client.New(
 		cfg,
 		client.Options{


### PR DESCRIPTION
Removing k8s client writer caching to ensure the fresh provided auth token
is propagated to client. A single level caching by token (with 10s TTL by default) should be enough.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=2015063