### PR TITLE
[BACKPORT] K8s client caching removal

### DIFF
--- a/pkg/backend/auth.go
+++ b/pkg/backend/auth.go
@@ -187,11 +187,6 @@ func (r *Auth) key(token, p string) string {
 //
 // Build API writer.
 func (r *Auth) writer(cfg *rest.Config) (w client.Writer, err error) {
-	if r.Writer != nil {
-		w = r.Writer
-		return
-	}
-
 	w, err = client.New(
 		cfg,
 		client.Options{


### PR DESCRIPTION
2.2 release backport of https://github.com/konveyor/forklift-must-gather-api/pull/14 - Removing k8s client writer caching to ensure the fresh provided auth token is propagated to client.

Should fix https://bugzilla.redhat.com/show_bug.cgi?id=2015063