### PR TITLE
Rename DEFAULT_IMAGE option to MUST_GATHER_IMAGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Option | Default value | Description
 --- | --- | ---
 PORT | ```8080``` | Port where the wrapper listens on
 DB_PATH | ```./gatherings.db``` | Local storage for must-gather executions records, can be ephemeral or just in memory ```file::memory:?cache=shared```
-DEFAULT_IMAGE | ```quay.io/konveyor/forklift-must-gather``` | Image name to be used if it was not specified in API call
+MUST_GATHER_IMAGE | ```quay.io/konveyor/forklift-must-gather``` | Image name to be used if it was not specified in API call
 TIMEOUT | ```20m``` | Timeout for must-gather execution
 ARCHIVE_FILENAME | ```must-gather.tar.gz``` | Archive filename to be searched in must-gather execution directory to be provided to user as the result archive
 CLEANUP_MAX_AGE | ```-1``` | Maximum age of must-gather executions kept available in the wrapper, -1 disables the deletion, e.g. ```24h```

--- a/pkg/must-gather-api.go
+++ b/pkg/must-gather-api.go
@@ -68,7 +68,7 @@ func triggerGathering(c *gin.Context) {
 	if err := c.Bind(&gathering); err == nil {
 		gathering.Status = "new"
 		if gathering.Image == "" {
-			gathering.Image = backend.ConfigEnvOrDefault("DEFAULT_IMAGE", "quay.io/konveyor/forklift-must-gather") // default image configurable via OS ENV vars
+			gathering.Image = backend.ConfigEnvOrDefault("MUST_GATHER_IMAGE", "quay.io/konveyor/forklift-must-gather") // default image configurable via OS ENV vars
 		}
 		if gathering.Timeout == "" {
 			gathering.Timeout = backend.ConfigEnvOrDefault("TIMEOUT", "20m") // default timeout for must-gather execution


### PR DESCRIPTION
Renaming option setting default must-gather image to MUST_GATHER_IMAGE
to provide more descriptive name.