### PR TITLE
[BACKPORT] Allow @ character in argument sanitizer

### DIFF
--- a/pkg/backend/tools.go
+++ b/pkg/backend/tools.go
@@ -14,7 +14,7 @@ func gatheringDir(gatheringID uint) string {
 // TODO: Consider make or use something nicer
 func sanitizeArg(str string) string {
 	output := ""
-	allowedChars := "QWERTZUIOPASDFGHJKLYXCVBNMqwertzuiopasdfghjklyxcvbnm1234567890_-~/:.= "
+	allowedChars := "QWERTZUIOPASDFGHJKLYXCVBNMqwertzuiopasdfghjklyxcvbnm1234567890_-~/:.=@ "
 	for _, rune := range str {
 		if strings.ContainsRune(allowedChars, rune) {
 			output += string(rune)


### PR DESCRIPTION
2.2 backport of https://github.com/konveyor/forklift-must-gather-api/pull/20

It is a common practice to use SHA256 signature of container
image names, like registry.example.com/app/web@sha256:<sig>.
The argument sanitizer doesn't allow the @ character, so these
image names will be truncated and will fail to be pulled.

This change adds the @ character in the accepted characters.