### PR TITLE
Add an option to run local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin
 *~
 *.swp
 *.retry
+*.vscode
 
 cover.out
 *.db

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ TIMEOUT | ```20m``` | Timeout for must-gather execution
 ARCHIVE_FILENAME | ```must-gather.tar.gz``` | Archive filename to be searched in must-gather execution directory to be provided to user as the result archive
 CLEANUP_MAX_AGE | ```-1``` | Maximum age of must-gather executions kept available in the wrapper, -1 disables the deletion, e.g. ```24h```
 DEBUG | ```(not set)``` | Set to enable debugging output when running in cluster, e.g. ```true```
+USE_KUBECONFIG | ```(not set)``` | Set to enable using local ```kubeconfig``` file, e.g. ```true```
 
 ## Notes
 


### PR DESCRIPTION
**Problem**:
It is not convenient to set up the API server for local development,
for example, when developing the UI it is sometimes nice to have a way to connect to a local forklift-must-gather-api server.

**What happen**:
Currently the server is hard coded to use in cluster configuration files:
```
"/var/run/secrets/kubernetes.io/serviceaccount/token"
"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
```
Settings this files on a developer machine requires root access.

**Suggested solution**:
Allow to use local kubeconfig file ( default or using `$KUBECONFIG` ) using an environment variable flag.

| var | description | default value
|-----|----------------|-------
| USE_KUBECONFIG | use local user's kubeconfig when fetching data from k8s server ("false"/"true") | "false"

For example:
```bash
PORT=9200 USE_KUBECONFIG=true go run pkg/must-gather-api.go
```

Ref: #11

Signed-off-by: yzamir <yzamir@redhat.com>